### PR TITLE
lm-eval-input-stats-as-histogram

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from lm_eval.api.model import LM
     from lm_eval.tasks import Task
 
+from lm_eval.utils import eval_logger
+
+LOGGER = eval_logger
 
 @positional_deprecated
 def simple_evaluate(
@@ -366,6 +369,17 @@ def evaluate(
 
         # run requests through model
         resps = getattr(lm, reqtype)(cloned_reqs)
+
+        # ---------------------------------------------------------
+        # MODIFIED CODE
+        try:
+            lm.task_input_stats.generate_report()
+            lm.task_input_stats.reset()
+        except Exception as err:
+            LOGGER.error(f"Failed to generate task_input_stats report. Error: {err}")
+        # END OF MODIFIED CODE
+        # ---------------------------------------------------------
+
 
         # put responses from model into a list of length K for each request.
         for x, req in zip(resps, cloned_reqs):

--- a/lm_eval/task_input_stats.py
+++ b/lm_eval/task_input_stats.py
@@ -1,6 +1,8 @@
 import io
 import numpy as np
 
+from collections import Counter
+
 from lm_eval.utils import eval_logger
 
 LOGGER = eval_logger
@@ -15,12 +17,12 @@ class TaskInputStats:
         output = io.StringIO()
 
         for i in range (0, bins):
-            print('{:12.5f}  | {:{width}s} {}'.format(
+            print('{:12.0f}  | {:{width}s} {}'.format(
                 b[i],
                 '#'*int(width*h[i]/np.amax(h)),
                 h[i],
                 width=width), file=output)
-        print('{:12.5f}  |'.format(b[bins]), file=output)
+        print('{:12.0f}  |'.format(b[bins]), file=output)
 
         contents = output.getvalue()
         output.close()
@@ -72,8 +74,8 @@ class TaskInputStats:
                         padded_prompts += 1
 
         LOGGER.info("----------------------------------------------------------------")
-        LOGGER.info(f"Requests (context) counts by token size. Length(tokens) | count\n{self.data_as_histogram(context_enc_)}")
-        LOGGER.info(f"Responses (continuation) counts by token size. Length(tokens) | count\n{self.data_as_histogram(continuation_enc_)}")
+        LOGGER.info(f"Requests (context) counts by token size. Length(tokens) | count\n{self.data_as_histogram(context_enc_, bins=min(30, 1 + len(Counter(context_enc_).keys())))}")
+        LOGGER.info(f"Responses (continuation) counts by token size. Length(tokens) | count\n{self.data_as_histogram(continuation_enc_, bins=min(30, 1 + len(Counter(continuation_enc_).keys())))}")
         LOGGER.info("----------------------------------------------------------------")
         LOGGER.info(f"Total prompts: {total_prompts}")
         LOGGER.info(f"Padded prompts: {padded_prompts}")

--- a/lm_eval/task_input_stats.py
+++ b/lm_eval/task_input_stats.py
@@ -1,10 +1,30 @@
+import io
+import numpy as np
+
 from lm_eval.utils import eval_logger
 
 LOGGER = eval_logger
 
+
 class TaskInputStats:
     def __init__(self):
         self._stats: list = list()
+
+    def data_as_histogram(self, a, bins=40, width=120) -> str:
+        h, b = np.histogram(a, bins)
+        output = io.StringIO()
+
+        for i in range (0, bins):
+            print('{:12.5f}  | {:{width}s} {}'.format(
+                b[i],
+                '#'*int(width*h[i]/np.amax(h)),
+                h[i],
+                width=width), file=output)
+        print('{:12.5f}  |'.format(b[bins]), file=output)
+
+        contents = output.getvalue()
+        output.close()
+        return contents
 
     def generate_report(self):
         stats = self._stats
@@ -25,13 +45,10 @@ class TaskInputStats:
         if items_inp != items_batch:
             LOGGER.warning(f"Uneven number of stats packets items_inp={items_inp} vs items_batch={items_batch}")
 
-        context_enc_size = dict()
-        continuation_enc_size = dict()
-
+        context_enc_ = list()
+        continuation_enc_ = list()
 
         inplen = None
-        inp_padding_len = None
-
         total_prompts = 0
         padded_prompts = 0
         truncated_prompts = 0
@@ -39,21 +56,11 @@ class TaskInputStats:
         for item in stats:
             for i in item:
                 if "context_enc" in i:
-                    if i["context_enc"] in context_enc_size:
-                        context_enc_size[i["context_enc"]] += 1
-                    else:
-                        context_enc_size[i["context_enc"]] = 1
-
-                    if i["continuation_enc"] in continuation_enc_size:
-                        continuation_enc_size[i["continuation_enc"]] += 1
-                    else:
-                        continuation_enc_size[i["continuation_enc"]] = 1
+                    context_enc_.append(i["context_enc"])
+                    continuation_enc_.append(i["continuation_enc"])
 
                     if inplen is None:
                         inplen = i["inplen"]
-
-                    if inp_padding_len is None:
-                        inp_padding_len = i["inp_padding_len"]
 
         for item in stats:
             for i in item:
@@ -65,14 +72,8 @@ class TaskInputStats:
                         padded_prompts += 1
 
         LOGGER.info("----------------------------------------------------------------")
-        LOGGER.info("Requests (context) counts by token size. Length(tokens) = count")
-        for key, value in context_enc_size.items():
-            LOGGER.info(f"{key}={value}")
-
-        LOGGER.info("Responses (continuation) counts by token size. Length(tokens) = count")
-        for key, value in continuation_enc_size.items():
-            LOGGER.info(f"{key}={value}")
-
+        LOGGER.info(f"Requests (context) counts by token size. Length(tokens) | count\n{self.data_as_histogram(context_enc_)}")
+        LOGGER.info(f"Responses (continuation) counts by token size. Length(tokens) | count\n{self.data_as_histogram(continuation_enc_)}")
         LOGGER.info("----------------------------------------------------------------")
         LOGGER.info(f"Total prompts: {total_prompts}")
         LOGGER.info(f"Padded prompts: {padded_prompts}")

--- a/scripts/make_table_results.py
+++ b/scripts/make_table_results.py
@@ -23,7 +23,7 @@ def make_table(result_dict):
     values = []
 
     for k, dic in sorted(result_dict["results"].items()):
-        version = result_dict["versions"][k]
+        version = result_dict["versions"].get(k, "N/A")
         percent = k == "squad2"
         for m, v in dic.items():
             if m.endswith("_stderr"):


### PR DESCRIPTION
Hi @maartenpants . I addressed your suggestions here. The sample output now looks like:

```
[03/18/2024 06:55:11 PM - INFO lm-eval] - ----------------------------------------------------------------
[03/18/2024 06:55:13 PM - INFO lm-eval] - Requests (context) counts by token size. Length(tokens) | count
          43  | ##############################################################################                                           196
          60  | ######################################################################################################################## 300
          77  | #########################################################################                                                184
          94  | #########################################################                                                                144
         111  | ###################################                                                                                      88
         128  | ####################                                                                                                     52
         145  | #########                                                                                                                24
         162  | ####                                                                                                                     12
         178  | ########                                                                                                                 20
         195  | ######                                                                                                                   16
         212  | ###########                                                                                                              28
         229  | ####                                                                                                                     12
         246  | ####                                                                                                                     12
         263  | ####                                                                                                                     12
         280  | #                                                                                                                        4
         297  | #                                                                                                                        4
         314  | ###                                                                                                                      8
         331  |                                                                                                                          0
         348  | ###                                                                                                                      8
         365  | #                                                                                                                        4
         382  | #                                                                                                                        4
         399  |                                                                                                                          0
         416  |                                                                                                                          0
         432  |                                                                                                                          0
         449  |                                                                                                                          0
         466  |                                                                                                                          0
         483  |                                                                                                                          0
         500  |                                                                                                                          0
         517  |                                                                                                                          0
         534  | ###                                                                                                                      8
         551  |

[03/18/2024 06:55:17 PM - INFO lm-eval] - Responses (continuation) counts by token size. Length(tokens) | count
           0  |                                                                                                                          0
           1  | ######################################################################################################################## 1140
           2  |

[03/18/2024 06:55:28 PM - INFO lm-eval] - ----------------------------------------------------------------
[03/18/2024 06:55:28 PM - INFO lm-eval] - Total prompts: 1140
[03/18/2024 06:55:28 PM - INFO lm-eval] - Padded prompts: 912
[03/18/2024 06:55:28 PM - INFO lm-eval] - Truncated prompts: 228
[03/18/2024 06:55:28 PM - INFO lm-eval] - ----------------------------------------------------------------
```